### PR TITLE
Fix default value for thirdPartyPaymentMethods

### DIFF
--- a/Resources/views/frontend/_public/src/js/jquery.swag-paypal-unified.payment-wall.js
+++ b/Resources/views/frontend/_public/src/js/jquery.swag-paypal-unified.payment-wall.js
@@ -133,9 +133,9 @@
              * Third party methods which will be shown in the payment wall iFrame
              * formatted as JSON string, will be decoded on calling `applyDataAttributes`
              *
-             * @type string
+             * @type Array
              */
-            thirdPartyPaymentMethods: ''
+            thirdPartyPaymentMethods: []
         },
 
         /**


### PR DESCRIPTION
Because https://github.com/shopwareLabs/SwagPaymentPayPalUnified/blob/1dd2fc1b73a33eb7ac1b6095305884e22104b9cb/Resources/views/frontend/_public/src/js/jquery.swag-paypal-unified.payment-wall-shipping-payment.js#L132 wants to iterate over that option the default value should be an array.