### PR TITLE
Use default Shopware-way to update order payment status

### DIFF
--- a/Components/Services/OrderDataService.php
+++ b/Components/Services/OrderDataService.php
@@ -40,30 +40,6 @@ class OrderDataService
     }
 
     /**
-     * @param string $orderNumber
-     * @param int    $paymentStatusId
-     *
-     * @return bool
-     */
-    public function applyPaymentStatus($orderNumber, $paymentStatusId)
-    {
-        $builder = $this->dbalConnection->createQueryBuilder();
-        $builder->update('s_order', 'o')
-            ->set('o.cleared', ':paymentStatus')
-            ->where('o.ordernumber = :orderNumber')
-            ->setParameters([
-                ':orderNumber' => $orderNumber,
-                ':paymentStatus' => $paymentStatusId,
-            ]);
-
-        if ($paymentStatusId === PaymentStatus::PAYMENT_STATUS_APPROVED) {
-            $builder->set('o.cleareddate', 'NOW()');
-        }
-
-        return $builder->execute() === 1;
-    }
-
-    /**
      * @param int    $orderNumber
      * @param string $transactionId
      *

--- a/Controllers/Frontend/PaypalUnified.php
+++ b/Controllers/Frontend/PaypalUnified.php
@@ -5,6 +5,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+use Doctrine\DBAL\Connection;
 use Shopware\Components\HttpClient\RequestException;
 use SwagPaymentPayPalUnified\Components\ErrorCodes;
 use SwagPaymentPayPalUnified\Components\ExceptionHandlerServiceInterface;
@@ -235,22 +236,18 @@ class Shopware_Controllers_Frontend_PaypalUnified extends \Shopware_Controllers_
             /** @var RelatedResource $responseSale */
             $responseSale = $response->getTransactions()->getRelatedResources()->getResources()[0];
 
-            // apply the payment status if its completed by PayPal
-            $paymentState = $responseSale->getState();
-            if ($paymentState === PaymentStatus::PAYMENT_COMPLETED &&
-                !$orderDataService->applyPaymentStatus($orderNumber, PaymentStatus::PAYMENT_STATUS_APPROVED)
-            ) {
-                $this->handleError(ErrorCodes::NO_ORDER_TO_PROCESS);
-
-                return;
-            }
-
             //Use TXN-ID instead of the PaymentId
             $saleId = $responseSale->getId();
             if (!$orderDataService->applyTransactionId($orderNumber, $saleId)) {
                 $this->handleError(ErrorCodes::NO_ORDER_TO_PROCESS);
 
                 return;
+            }
+
+            // apply the payment status if its completed by PayPal
+            $paymentState = $responseSale->getState();
+            if ($paymentState === PaymentStatus::PAYMENT_COMPLETED) {
+                $this->markOrderAsPayed($saleId, $paymentId);
             }
 
             // Save payment instructions from PayPal to database.
@@ -283,6 +280,30 @@ class Shopware_Controllers_Frontend_PaypalUnified extends \Shopware_Controllers_
         } catch (\Exception $exception) {
             $this->handleError(ErrorCodes::UNKNOWN, $exception);
         }
+    }
+
+    /**
+     * @param string $saleId
+     * @param string $paymentId
+     */
+    private function markOrderAsPayed($saleId, $paymentId)
+    {
+        $this->savePaymentStatus($saleId, $paymentId, PaymentStatus::PAYMENT_STATUS_APPROVED, false);
+
+        /** @var Connection $dbalConnection */
+        $dbalConnection = $this->get('dbal_connection');
+        $builder = $dbalConnection->createQueryBuilder();
+        $builder
+            ->update('s_order', 'o')
+            ->set('o.cleareddate', 'NOW()')
+            ->where('o.transactionID = :transactionId')
+            ->andWhere('o.temporaryID = :temporaryId')
+            ->setParameters([
+                ':transactionId' => $saleId,
+                ':temporaryId' => $paymentId,
+            ]);
+
+        $builder->execute();
     }
 
     /**

--- a/Tests/Functional/Components/Services/OrderDataServiceTest.php
+++ b/Tests/Functional/Components/Services/OrderDataServiceTest.php
@@ -34,33 +34,6 @@ class OrderDataServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(OrderDataService::class, $orderDataService);
     }
 
-    public function test_apply_order_status_without_existing_order_returns_false()
-    {
-        $orderDataService = $this->getOrderDataService();
-
-        $this->assertFalse($orderDataService->applyPaymentStatus('WRONG_ORDER_NUMBER', self::PAYMENT_STATUS_APPROVED));
-    }
-
-    public function test_should_update_order_status()
-    {
-        $orderDataService = $this->getOrderDataService();
-
-        $orderDataService->applyPaymentStatus(self::ORDER_NUMBER, self::PAYMENT_STATUS_APPROVED);
-
-        /** @var Connection $dbalConnection */
-        $dbalConnection = Shopware()->Container()->get('dbal_connection');
-        $updatedOrder = $dbalConnection->executeQuery('SELECT * FROM s_order WHERE ordernumber="' . self::ORDER_NUMBER . '"')->fetchAll();
-
-        $this->assertEquals(self::PAYMENT_STATUS_APPROVED, $updatedOrder[0]['cleared']);
-    }
-
-    public function test_apply_transaction_id_without_existing_order_returns_false()
-    {
-        $orderDataService = $this->getOrderDataService();
-
-        $this->assertFalse($orderDataService->applyPaymentStatus('WRONG_ORDER_NUMBER', self::PAYMENT_STATUS_APPROVED));
-    }
-
     public function test_should_update_transaction_id()
     {
         $orderDataService = $this->getOrderDataService();


### PR DESCRIPTION
### 1. Why is this change necessary?
The **PayPal Unified** plugin currently sets the payment status of an order directly via a SQL query. Therefore other plugins cannot track changes of the payment status because this does not triggers any of the usual hooks (e.g. hooks of the methods in the doctrine model or `sOrder` class).

Also no order status history entry is written.

### 2. What does this change do, exactly?
This PR changes the `returnAction` of the `Shopware_Controllers_Frontend_PaypalUnified` controller to use the method `\Shopware_Controllers_Frontend_Payment::savePaymentStatus` to save the order payment status. This method is part of SW and can easily be hooked by any plugins independently of which payment provider is used.

The method `\SwagPaymentPayPalUnified\Components\Services\OrderDataService::applyPaymentStatus` is removed. Please note, that this is a backward incompatiple change, but it is necessary.