### PR TITLE
Always add the document boxes to correct field set

### DIFF
--- a/Resources/views/backend/config/view/form/document_paypal_unified.js
+++ b/Resources/views/backend/config/view/form/document_paypal_unified.js
@@ -16,10 +16,21 @@ Ext.define('Shopware.apps.Config.view.form.DocumentPaypalUnified', {
      * @return { Array }
      */
     getFormItems: function() {
-        var me = this,
-            data = me.callParent(arguments);
+        var formItems = this.callParent(arguments);
 
-        data[1].items.push({
+        var elementFieldSetIndex = -1;
+        formItems.forEach(function (item, index) {
+            if (item && item.name === 'elementFieldSet') {
+                elementFieldSetIndex = index;
+
+                return false;
+            }
+        });
+        if (elementFieldSetIndex === -1) {
+            return formItems;
+        }
+
+        formItems[elementFieldSetIndex].items.push({
             xtype: 'tinymce',
             fieldLabel: '{s name=document/detail/content_footer_label}Footer content{/s}',
             labelWidth: 100,
@@ -49,7 +60,7 @@ Ext.define('Shopware.apps.Config.view.form.DocumentPaypalUnified', {
             translatable: true
         });
 
-        return data;
+        return formItems;
     }
 });
 // {/block}


### PR DESCRIPTION
The override of the method `getFormItems` in the ExtJS class `Shopware.apps.Config.view.form.DocumentPaypalUnified` is used to add the document elements of paypal to the document element configuration in the backend.

![image](https://user-images.githubusercontent.com/15085275/45361384-55ad9900-b5d2-11e8-8acf-f64a2f6c2b1e.png)

Unfortunately the override always adds this to the second field set found in the right panel of the window. In case another plugin adds a field set before, then the override will add the document elements to the wrong fieldset. Therefore they will not be editable for the user anymore.


![image](https://user-images.githubusercontent.com/15085275/45361441-737afe00-b5d2-11e8-8a75-28a25b2b83b6.png)


The PR improves the determination of the correct field set so that the document element are always added to the correct fieldset.