### PR TITLE
bugfix: only replace necessary paypal boxes with its content

### DIFF
--- a/Components/Document/InvoiceDocumentHandler.php
+++ b/Components/Document/InvoiceDocumentHandler.php
@@ -45,36 +45,47 @@ class InvoiceDocumentHandler
      */
     public function handleDocument($orderNumber, Document $document)
     {
-        //Collect all available containers in order to work with some of them later.
-        /** @var array $templateContainers */
-        $templateContainers = $document->_view->getTemplateVars('Containers');
-        /** @var \Smarty_Data $view */
-        $view = $document->_view;
-        /** @var array $orderData */
-        $orderData = $view->getTemplateVars('Order');
-        $orderData = $this->overwritePaymentName($orderData);
+        // replace the contents only for that document types,
+        // whose really has PayPal boxes assigned to it:
+        if ($this->hasPayPalUnifiedBoxes($document)) {
 
-        //Get the new footer for the document and replace the original one
-        $rawFooter = $this->getInvoiceContainer($templateContainers, $orderData);
-        $templateContainers['PayPal_Unified_Instructions_Content']['value'] = $rawFooter['value'];
+            //Collect all available containers in order to work with some of them later.
+            /** @var array $templateContainers */
+            $templateContainers = $document->_view->getTemplateVars('Containers');
+            /** @var \Smarty_Data $view */
+            $view = $document->_view;
 
-        $view->assign('Order', $orderData);
-        $view->assign('Containers', $templateContainers);
+            /** @var array $orderData */
+            $orderData = $view->getTemplateVars('Order');
+            $orderData = $this->overwritePaymentName($orderData);
 
-        $instructions = $this->instructionService->getInstructions($orderNumber);
-        if ($instructions) {
-            $document->_template->assign('PayPalUnifiedInvoiceInstruction', $instructions->toArray());
+            //Get the new footer for the document and replace the original one
+            $rawFooter = $this->getInvoiceContainer($templateContainers, $orderData);
+            $templateContainers['PayPal_Unified_Instructions_Content']['value'] = $rawFooter['value'];
+
+            $view->assign('Order', $orderData);
+            $view->assign('Containers', $templateContainers);
+
+            $instructions = $this->instructionService->getInstructions($orderNumber);
+            if ($instructions) {
+                $document->_template->assign(
+                    'PayPalUnifiedInvoiceInstruction',
+                    $instructions->toArray()
+                );
+            }
+
+            //Reassign the complete template including the new variables.
+            /** @var array $containerData */
+            $containerData = $view->getTemplateVars('Containers');
+            $containerData['Footer'] = $containerData['PayPal_Unified_Instructions_Footer'];
+            $containerData['Content_Info'] = $containerData['PayPal_Unified_Instructions_Content'];
+            $containerData['Content_Info']['value'] = $document->_template->fetch(
+                'string:' . $containerData['Content_Info']['value']
+            );
+            $containerData['Content_Info']['style'] = '}'.$containerData['Content_Info']['style'] . ' #info {';
+
+            $view->assign('Containers', $containerData);
         }
-
-        //Reassign the complete template including the new variables.
-        /** @var array $containerData */
-        $containerData = $view->getTemplateVars('Containers');
-        $containerData['Footer'] = $containerData['PayPal_Unified_Instructions_Footer'];
-        $containerData['Content_Info'] = $containerData['PayPal_Unified_Instructions_Content'];
-        $containerData['Content_Info']['value'] = $document->_template->fetch('string:' . $containerData['Content_Info']['value']);
-        $containerData['Content_Info']['style'] = '}' . $containerData['Content_Info']['style'] . ' #info {';
-
-        $view->assign('Containers', $containerData);
     }
 
     /**
@@ -101,6 +112,24 @@ class InvoiceDocumentHandler
         }
 
         return $rawFooter;
+    }
+
+    /**
+     * Searches in a given document template for the PayPal Unified boxes.
+     *
+     * @param Document $doc
+     * @return bool
+     */
+    public function hasPayPalUnifiedBoxes(Document $doc)
+    {
+        $query = 'SELECT id FROM s_core_documents_box WHERE documentID = ? AND `name` = ?;';
+
+        $boxTest = $this->dbalConnection->fetchAssoc(
+            $query,
+            [$doc->_typID, 'PayPal_Unified_Instructions_Content']
+        );
+
+        return is_array($boxTest) && count($boxTest) > 0;
     }
 
     /**


### PR DESCRIPTION
Hi,
we found a bug in the plugin.
### Description of the given behaviour
If you define own documents in the shopware backend, which has the smarty template "index.tpl" the smarty block e. g. "Footer" is been accidently replaced by "PayPal_Unified_Instructions_Footer", which would be ``null`` on own templates. So it replaces all templates, not only the invoice (as it should only do so, or on templates which have the three PayPal smarty blocks).
### What fixes the PR?
I have written a method on that service class, which checks for the existance of the block "PayPal_Unified_Instructions_Content" on the given ``Document::$_typID``. If so, the replacement happens. Otherwise nothing is been replaced on that document.
### Did I have written tests for verfiy it?
Well, I didn't. But you can easily do a whitebox test in the backend:
1. create an own document
2. Set the template to ``index.tpl`` or create an own, which inherits from ``index.tpl``. All the other basic settings doesn't matter for that test case.
3. Replace the block ``Footer`` with some custom content in order to see difference later in the generated PDF.
4. Go to Orders and pick one PayPal Plus invoice order
5. Switch to documents, choose your just created document and click on "preview".
6. You should now see, that the "Footer" is totally missing. If you already installed the changes made by this PR, you should indeed see a "Footer".

I hope this is helpfull.

Kind Regards,

alpham8