### PR TITLE
Fix order list exclusion

### DIFF
--- a/Controllers/Backend/PaypalUnified.php
+++ b/Controllers/Backend/PaypalUnified.php
@@ -499,7 +499,7 @@ class Shopware_Controllers_Backend_PaypalUnified extends Shopware_Controllers_Ba
         $conditions[] = [
             'property' => 'sOrder.number',
             'expression' => '!=',
-            'value' => 0,
+            'value' => '0',
         ];
 
         return $conditions;


### PR DESCRIPTION
In the paypal order list, canceled or temporary orders are filtered so that only normal orders are listed.
As discovered during the development of our new shop, prefixed ordernumbers are also excluded due to probably some casting issues.
Changing the type of value from int to string fixed the problem with our prefixed ordernumbers.

![Bildschirmfoto 2019-04-04 um 14 12 54](https://user-images.githubusercontent.com/3511228/55562501-5899e380-56f4-11e9-9802-a363eab3ea82.png)
![Bildschirmfoto 2019-04-04 um 14 13 46](https://user-images.githubusercontent.com/3511228/55562502-5899e380-56f4-11e9-810a-b81dda1f2263.png)