### PR TITLE
Paypal Plugin In-context $.ajax Response Fehler

### DIFF
--- a/Controllers/Frontend/PaypalUnified.php
+++ b/Controllers/Frontend/PaypalUnified.php
@@ -60,6 +60,15 @@ class Shopware_Controllers_Frontend_PaypalUnified extends \Shopware_Controllers_
      */
     private $shopwareConfig;
 
+    public function dispatch($action)
+    {
+        $useInContext = (bool) $this->Request()->getParam('useInContext', false);
+        if ($useInContext && $this->Request()->getActionName() === 'gateway') {
+            $this->Front()->Plugins()->Json()->setRenderer();
+        }
+        parent::dispatch($action);
+    }
+
     public function preDispatch()
     {
         $this->paymentResource = $this->get('paypal_unified.payment_resource');


### PR DESCRIPTION
das Fehlermeldung kommt

"Während des Bezahlvorganges mit PayPal ist ein Fehler aufgetreten. PayPal steht Ihnen gegenwärtig nicht zur Verfügung."

ohne Fehler in console oder in log Datei.

voll details :

https://forum.shopware.com/discussion/60243/paypal-plugin-in-context-fehler console_screenshot.png

Issue Tickte : [PT-10373](https://issues.shopware.com/issues/PT-10373)