### PR TITLE
prevent errors on empty baskets

### DIFF
--- a/Subscriber/Plus.php
+++ b/Subscriber/Plus.php
@@ -152,6 +152,10 @@ class Plus implements SubscriberInterface
         /** @var \Enlight_View_Default $view */
         $view = $controller->View();
 
+        if ($session->offsetGet('sBasketQuantity') === 0) {
+            return;
+        }
+
         $errorCode = $request->getParam('paypal_unified_error_code');
         $errorName = $request->getParam('paypal_unified_error_name');
         $errorMessage = $request->getParam('paypal_unified_error_message');


### PR DESCRIPTION
The payment wall will throw an exception when the basket is empty. You will get some log entries like this one:

```
PayPal: Could not create payment for plus payment wall due to a communication failure

{
  "message": "Client error response [url] https://api.sandbox.paypal.com/v1/payments/payment [status code] 400 [reason phrase] Bad Request",
  "payload": "{\"name\":\"VALIDATION_ERROR\",\"details\":[{\"field\":\"transactions[0].amount\",\"issue\":\"Amount cannot be zero\"}],\"message\":\"Invalid request - see details\",\"information_link\":\"https://developer.paypal.com/docs/api/payments/#errors\",\"debug_id\":\"63f3caf410ec2\"}"
}
```

There are many possibilities where this could happen:
- session timeout on cart page
- user registration without products in cart (fixed in 5.5.9)
- payment errors on PayPal

Since there is already a ticket for the PayPal case, it would be nice to fix the error-message for all other occurrences by checking if there is something in the cart.