### PR TITLE
bugfix: change payment method for PayPal plus

### DIFF
--- a/Resources/views/frontend/paypal_unified/plus/checkout/payment_wall_shipping_payment.tpl
+++ b/Resources/views/frontend/paypal_unified/plus/checkout/payment_wall_shipping_payment.tpl
@@ -1,6 +1,7 @@
 {block name='frontend_checkout_shipping_payment_paypal_unified_payment_wall_plugin'}
     {* Payment wall plugin *}
     <div class="is--hidden"
+         data-paypalApprovalUrl="{$paypalUnifiedApprovalUrl}"
          data-paypaLPaymentWall="true"
          data-paypalLanguage="{$paypalUnifiedLanguageIso}"
          data-paypalCountryIso="{$sUserData.additional.country.countryiso}"


### PR DESCRIPTION
Without this option, users see the following in the payment method selection list:
http://dl3.joxi.net/drive/2019/07/09/0026/1778/1763058/58/24eb6ea214.jpg
https://www.paypalobjects.com/webstatic/ppplus/public/pages/en_US/notavailableerror.html    ( iframe URL ) 

The problem was that the "js file"   https://www.paypalobjects.com/webstatic/ppplus/ppplus.min.js
was tried to use "ApprovalUrl"  parameter. 
http://dl3.joxi.net/drive/2019/07/09/0026/1778/1763058/58/25402b15b3.jpg
And since the parameter is missing, I received an error...  

Аfter adding the missing parameter, everything worked.
http://dl4.joxi.net/drive/2019/07/09/0026/1778/1763058/58/5d7041931c.jpg

Shopware: 5.5.8 
SwagPaymentPayPalUnified: 2.2.4