### PR TITLE
Add checkbox as product attribute to exclude paypal express

### DIFF
--- a/Resources/snippets/backend/attribute_columns.ini
+++ b/Resources/snippets/backend/attribute_columns.ini
@@ -3,9 +3,14 @@ s_core_paymentmeans_attributes_swag_paypal_unified_display_in_plus_iframe_label 
 s_core_paymentmeans_attributes_swag_paypal_unified_display_in_plus_iframe_helpText = "Activate this option, to display this payment method in the PayPal Plus iFrame"
 s_core_paymentmeans_attributes_swag_paypal_unified_plus_iframe_payment_logo_label = "Payment logo for iFrame"
 s_core_paymentmeans_attributes_swag_paypal_unified_plus_iframe_payment_logo_helpText = "Simply put an URL to an image here, if you want to show a logo for this payment in the PayPal Plus iFrame.<br><ul><li>The URL must be secure (https)</li><li>The image size must be maximum 100x25px</li></ul>"
+s_articles_attributes_swag_paypal_unified_express_disabled_label = "Disable Paypal Express"
+s_articles_attributes_swag_paypal_unified_express_disabled_helpText = "You can disable the Paypal Express button for this specific product with this checkbox"
+
 
 [de_DE]
 s_core_paymentmeans_attributes_swag_paypal_unified_display_in_plus_iframe_label = "Zeige im PayPal Plus iFrame"
 s_core_paymentmeans_attributes_swag_paypal_unified_display_in_plus_iframe_helpText = "Aktiviere diese Option, um diese Zahlungsart im PayPal Plus iFrame anzuzeigen"
 s_core_paymentmeans_attributes_swag_paypal_unified_plus_iframe_payment_logo_label = "Logo Zahlungsart für iFrame"
 s_core_paymentmeans_attributes_swag_paypal_unified_plus_iframe_payment_logo_helpText = "Geben Sie hier einfach eine URL zu einem Bild ein, wenn Sie ein Logo für diese Zahlung im PayPal Plus iFrame anzeigen möchten.<br><ul><li>Die URL muss sicher sein (https)</li><li><li>Die Bildgröße darf maximal 100x25px betragen</li></ul>"
+s_articles_attributes_swag_paypal_unified_express_disabled_label = "Paypal Express deaktivieren"
+s_articles_attributes_swag_paypal_unified_express_disabled_helpText = "Mit dieser Checkbox kannst du Paypal Express für dieses Produkt deaktivieren"

--- a/Resources/views/frontend/checkout/ajax_cart.tpl
+++ b/Resources/views/frontend/checkout/ajax_cart.tpl
@@ -3,9 +3,13 @@
 {* PayPal Express Checkout integration *}
 {block name='frontend_checkout_ajax_cart_button_container_inner'}
     {$smarty.block.parent}
-
     {block name='frontend_checkout_ajax_cart_button_container_inner_paypal_unified_ec_button'}
-        {if $paypalUnifiedEcOffCanvasActive && $paypalUnifiedUseInContext !== null}
+        {foreach $sBasket.content as $product}
+            {if $product.additional_details.swag_paypal_unified_express_disabled}
+                {assign var="swag_paypal_unified_express_disabled" value="1"}
+            {/if}
+        {/foreach}
+        {if $paypalUnifiedEcOffCanvasActive && $paypalUnifiedUseInContext !== null && !$swag_paypal_unified_express_disabled }
             {include file='frontend/paypal_unified/express_checkout/button_cart.tpl' paypalEcAjaxCart = true}
         {/if}
     {/block}

--- a/Resources/views/frontend/checkout/cart.tpl
+++ b/Resources/views/frontend/checkout/cart.tpl
@@ -20,7 +20,12 @@
     {$smarty.block.parent}
 
     {block name='frontend_checkout_cart_table_actions_paypal_unified_ec_button'}
-        {if $paypalUnifiedEcCartActive && $paypalUnifiedUseInContext !== null}
+        {foreach $sBasket.content as $product}
+            {if $product.additional_details.swag_paypal_unified_express_disabled}
+                {assign var="swag_paypal_unified_express_disabled" value="1"}
+            {/if}
+        {/foreach}
+        {if $paypalUnifiedEcOffCanvasActive && $paypalUnifiedUseInContext !== null && !$swag_paypal_unified_express_disabled }
             {include file='frontend/paypal_unified/express_checkout/button_cart.tpl'}
         {/if}
     {/block}

--- a/Resources/views/frontend/detail/buy.tpl
+++ b/Resources/views/frontend/detail/buy.tpl
@@ -20,7 +20,7 @@
     {$smarty.block.parent}
 
     {block name='frontend_detail_buy_button_paypal_unified_installments'}
-        {if !($sArticle.sConfigurator && !$activeConfiguratorSelection) && $paypalUnifiedEcDetailActive}
+        {if !($sArticle.sConfigurator && !$activeConfiguratorSelection) && $paypalUnifiedEcDetailActive && !$sArticle.swag_paypal_unified_express_disabled}
             {include file='frontend/paypal_unified/express_checkout/button_detail.tpl'}
         {/if}
     {/block}

--- a/Setup/Installer.php
+++ b/Setup/Installer.php
@@ -136,7 +136,19 @@ class Installer
             ]
         );
 
-        $this->modelManager->generateAttributeModels(['s_order_attributes', 's_core_paymentmeans_attributes']);
+        $this->attributeCrudService->update(
+            's_articles_attributes',
+            'swag_paypal_unified_express_disabled',
+            'boolean',
+            [
+                'position' => -99,
+                'displayInBackend' => true,
+                'label' => 'Disable Paypal Express',
+                'helpText' => 'You can disable the Paypal Express button for this specific product with this checkbox',
+            ]
+        );
+
+        $this->modelManager->generateAttributeModels(['s_order_attributes', 's_core_paymentmeans_attributes', 's_articles_attributes']);
     }
 
     private function createDocumentTemplates()

--- a/Setup/Uninstaller.php
+++ b/Setup/Uninstaller.php
@@ -71,7 +71,14 @@ class Uninstaller
                 'swag_paypal_unified_plus_iframe_payment_logo'
             );
         }
-        $this->modelManager->generateAttributeModels(['s_core_paymentmeans_attributes']);
+
+        if ($this->attributeCrudService->get('s_articles_attributes', 'swag_paypal_unified_express_disabled') !== null) {
+            $this->attributeCrudService->delete(
+                's_articles_attributes',
+                'swag_paypal_unified_express_disabled'
+            );
+        }
+        $this->modelManager->generateAttributeModels(['s_core_paymentmeans_attributes', 's_articles_attributes']);
     }
 
     private function removeSettingsTables()


### PR DESCRIPTION
This PR adds a checkbox to the product that enables the user to hide the paypal express button in the detail views, the off-canvas and the checkout/cart page.