### PR TITLE
add payment token for plus, installment and classic

### DIFF
--- a/Components/DependencyProvider.php
+++ b/Components/DependencyProvider.php
@@ -62,14 +62,10 @@ class DependencyProvider
      */
     public function getToken()
     {
-        return $this->container->get(\Shopware\Components\Cart\PaymentTokenService::class)->generate();
-    }
-
-    /**
-     * Returns shopware version.
-     */
-    public function getVersion()
-    {
-        return $this->container->get('config')->get('version');
+        if ($this->container->has(\Shopware\Components\Cart\PaymentTokenService::class)) {
+            return $this->container->get(\Shopware\Components\Cart\PaymentTokenService::class)->generate();
+        } else {
+            return false;
+        }
     }
 }

--- a/Components/DependencyProvider.php
+++ b/Components/DependencyProvider.php
@@ -56,4 +56,20 @@ class DependencyProvider
     {
         return $this->container->get('session');
     }
+
+    /**
+     * Returns the payment token.
+     */
+    public function getToken()
+    {
+        return $this->container->get(\Shopware\Components\Cart\PaymentTokenService::class)->generate();
+    }
+
+    /**
+     * Returns shopware version.
+     */
+    public function getVersion()
+    {
+        return $this->container->get('config')->get('version');
+    }
 }

--- a/Components/Services/Installments/InstallmentsPaymentBuilderService.php
+++ b/Components/Services/Installments/InstallmentsPaymentBuilderService.php
@@ -8,12 +8,35 @@
 
 namespace SwagPaymentPayPalUnified\Components\Services\Installments;
 
+use Shopware\Components\Routing\RouterInterface;
+use Shopware_Components_Snippet_Manager as SnippetManager;
+use SwagPaymentPayPalUnified\Components\DependencyProvider;
+use SwagPaymentPayPalUnified\PayPalBundle\Components\SettingsServiceInterface;
 use SwagPaymentPayPalUnified\Components\PaymentBuilderParameters;
 use SwagPaymentPayPalUnified\Components\Services\PaymentBuilderService;
 use SwagPaymentPayPalUnified\PayPalBundle\Components\SettingsTable;
 
 class InstallmentsPaymentBuilderService extends PaymentBuilderService
 {
+
+    /**
+     * @var DependencyProvider
+     */
+    private $dependencyProvider;
+
+    public function __construct(
+        RouterInterface $router,
+        SettingsServiceInterface $settingsService,
+        SnippetManager $snippetManager,
+        dependencyProvider $dependencyProvider
+    ) {
+        parent::__construct($router, $settingsService, $snippetManager, $dependencyProvider);
+
+        $this->dependencyProvider = $dependencyProvider;
+
+    }
+
+
     /**
      * {@inheritdoc}
      */
@@ -42,6 +65,20 @@ class InstallmentsPaymentBuilderService extends PaymentBuilderService
      */
     private function getReturnUrl()
     {
+
+        if (version_compare($this->dependencyProvider->getVersion(),'5.6.0','>=')) {
+            
+            $token = $this->dependencyProvider->getToken();
+
+            return $this->router->assemble([
+                'controller' => 'PaypalUnifiedInstallments',
+                'action' => 'return',
+                'forceSecure' => true,
+                'basketId' => $this->requestParams->getBasketUniqueId(),
+                'swPaymentToken' => $token,
+            ]);
+        }
+
         if ($this->requestParams->getBasketUniqueId()) {
             return $this->router->assemble([
                 'controller' => 'PaypalUnifiedInstallments',

--- a/Components/Services/Installments/InstallmentsPaymentBuilderService.php
+++ b/Components/Services/Installments/InstallmentsPaymentBuilderService.php
@@ -65,11 +65,9 @@ class InstallmentsPaymentBuilderService extends PaymentBuilderService
      */
     private function getReturnUrl()
     {
+        $token = $this->dependencyProvider->getToken();
 
-        if (version_compare($this->dependencyProvider->getVersion(),'5.6.0','>=')) {
-            
-            $token = $this->dependencyProvider->getToken();
-
+        if ($token) {
             return $this->router->assemble([
                 'controller' => 'PaypalUnifiedInstallments',
                 'action' => 'return',

--- a/Components/Services/PaymentBuilderService.php
+++ b/Components/Services/PaymentBuilderService.php
@@ -242,9 +242,25 @@ class PaymentBuilderService implements PaymentBuilderInterface
      */
     private function getRedirectUrl($action)
     {
+        if (version_compare($this->dependencyProvider->getVersion(),'5.6.0','>=')) {
+            
+            $token = $this->dependencyProvider->getToken();
+
+            return $this->router->assemble(
+                [
+                    'controller' => 'PaypalUnified',
+                    'action' => $action,
+                    'forceSecure' => true,
+                    'basketId' => $this->requestParams->getBasketUniqueId(),
+                    'swPaymentToken' => $token,
+                ]
+            );
+        }
+
         //Shopware 5.3 + supports cart validation.
         //In order to use it, we have to slightly modify the return URL.
         if ($this->requestParams->getBasketUniqueId()) {
+
             return $this->router->assemble(
                 [
                     'controller' => 'PaypalUnified',

--- a/Components/Services/PaymentBuilderService.php
+++ b/Components/Services/PaymentBuilderService.php
@@ -242,10 +242,9 @@ class PaymentBuilderService implements PaymentBuilderInterface
      */
     private function getRedirectUrl($action)
     {
-        if (version_compare($this->dependencyProvider->getVersion(),'5.6.0','>=')) {
-            
-            $token = $this->dependencyProvider->getToken();
+        $token = $this->dependencyProvider->getToken();
 
+        if ($token) {
             return $this->router->assemble(
                 [
                     'controller' => 'PaypalUnified',

--- a/Components/Services/Plus/PlusPaymentBuilderService.php
+++ b/Components/Services/Plus/PlusPaymentBuilderService.php
@@ -62,10 +62,9 @@ class PlusPaymentBuilderService extends PaymentBuilderService
      */
     private function getReturnUrl()
     {
-        if (version_compare($this->dependencyProvider->getVersion(),'5.6.0','>=')) {
-            
-            $token = $this->dependencyProvider->getToken();
+        $token = $this->dependencyProvider->getToken();
 
+        if ($token) {
             return $this->router->assemble([
                 'action' => 'return',
                 'controller' => 'PaypalUnified',

--- a/Components/Services/Plus/PlusPaymentBuilderService.php
+++ b/Components/Services/Plus/PlusPaymentBuilderService.php
@@ -27,6 +27,11 @@ class PlusPaymentBuilderService extends PaymentBuilderService
      */
     private $attributeService;
 
+    /**
+     * @var DependencyProvider
+     */
+    private $dependencyProvider;
+
     public function __construct(
         RouterInterface $router,
         SettingsServiceInterface $settingsService,
@@ -37,6 +42,7 @@ class PlusPaymentBuilderService extends PaymentBuilderService
         parent::__construct($router, $settingsService, $snippetManager, $dependencyProvider);
 
         $this->attributeService = $crudService;
+        $this->dependencyProvider = $dependencyProvider;
     }
 
     /**
@@ -56,6 +62,20 @@ class PlusPaymentBuilderService extends PaymentBuilderService
      */
     private function getReturnUrl()
     {
+        if (version_compare($this->dependencyProvider->getVersion(),'5.6.0','>=')) {
+            
+            $token = $this->dependencyProvider->getToken();
+
+            return $this->router->assemble([
+                'action' => 'return',
+                'controller' => 'PaypalUnified',
+                'forceSecure' => true,
+                'plus' => true,
+                'basketId' => BasketIdWhitelist::WHITELIST_IDS['PayPalPlus'],
+                'swPaymentToken' => $token,
+            ]);
+        }
+
         return $this->router->assemble([
             'action' => 'return',
             'controller' => 'PaypalUnified',


### PR DESCRIPTION
This PR adds the payment token from 5.6 to the plugin.
The only point where it is still missing is the express checkout, but it did't found a working way to implement it. I willl add it, when I found a working way to do it.