### PR TITLE
Add express checkout v2 to address validator

### DIFF
--- a/Bundle/AccountBundle/Service/Validator/AddressValidatorDecorator.php
+++ b/Bundle/AccountBundle/Service/Validator/AddressValidatorDecorator.php
@@ -45,7 +45,7 @@ class AddressValidatorDecorator implements AddressValidatorInterface
         }
 
         $controllerName = $request->getControllerName();
-        $payPalController = ['paypal_unified_express_checkout', 'paypalunifiedexpresscheckout'];
+        $payPalController = ['paypal_unified_express_checkout', 'paypalunifiedexpresscheckout', 'paypalunifiedv2expresscheckout'];
         if (!\in_array(\strtolower($controllerName), $payPalController, true)) {
             $this->innerValidator->validate($address);
 


### PR DESCRIPTION
Hey we had trouble with the express checkout if the customer doesn't provide a phone number. But the shop requires it. This solved the issue.

SW version 5.7.7 
Plugin Version 4.0.2. 