### PR TITLE
Update phone condition on PayUponInvoice

### DIFF
--- a/Subscriber/PayUponInvoice.php
+++ b/Subscriber/PayUponInvoice.php
@@ -96,7 +96,7 @@ class PayUponInvoice implements SubscriberInterface
 
         $customerData = $this->session->offsetGet('sOrderVariables')['sUserData'];
 
-        if (!isset($customerData['billingaddress']['phone'])) {
+        if (!isset($customerData['billingaddress']['phone']) || empty($customerData['billingaddress']['phone'])) {
             $viewAssignVariables['showPayUponInvoicePhoneField'] = true;
         }
 


### PR DESCRIPTION
$customerData['billingaddress']['phone'] can also be just an empty string.

it seems that in some Shopware Versions (in this case 5.5.4), the database field "phone" in table s_user_billingaddress is not even nullable.
So it is delivered by an empty string. Therefore the Paypal API throwing a 400 error because of missing phonenumber

![image](https://user-images.githubusercontent.com/5836639/193217040-9445098b-44f8-4ba3-97a9-6969f56fb692.png)
